### PR TITLE
Add blankIfUnexpanded with true value by default

### DIFF
--- a/local-script/plugin.yaml
+++ b/local-script/plugin.yaml
@@ -25,7 +25,8 @@ providers:
         name: script
         title: script
         description: "the shell script"
-        required: true        
+        required: true
+        blankIfUnexpanded: true
         renderingOptions:
           displayType: CODE
           codeSyntaxMode: SH
@@ -47,7 +48,8 @@ providers:
         name: script
         title: script
         description: "the shell script"
-        required: true        
+        required: true
+        blankIfUnexpanded: true
         renderingOptions:
           displayType: CODE
           codeSyntaxMode: SH
@@ -56,6 +58,7 @@ providers:
         title: Arguments
         description: "optional command line arguments"
         required: false
+        blankIfUnexpanded: true
       - type: String
         name: tmp
         title: Temporary path


### PR DESCRIPTION
## Describe Bug:
Jobs using nixy that were worked on 4.8 stopped working properly on 4.14.x and 4.15.x

**My Rundeck detail**

Rundeck version: [ 4.8.0 , 4.14 ]

install type: [ deb, war ]

OS Name/version: [ ubuntu 20, ubuntu 22, macOs, windows]

DB Type/version: [ Mariadb, H2 ]

**To Reproduce**  

Steps to reproduce the behavior:

1- Install rundeck 4.8 and upload the yaml that I leave here. 

2- Run that job and you will see that the output is ok

3- Install rundeck 4.14 and do the same

4- You will see that the jobs failed

<img width="1429" alt="image" src="https://github.com/rundeck/rundeck/assets/91557307/2303808e-aad3-4943-be5d-8f3bcf7aedb6">

**Expected behavior**  

We expected that the Nixy plugin works fine on both versions.

## Solution
The field `blankIfUnexpanded` is added as true by default.

<img width="1422" alt="image" src="https://github.com/rundeck/rundeck/assets/91557307/75725586-107e-4765-b0fc-da64b5670ddb">