### PR TITLE
RUN-3029: Fix Name concurrency > 1

### DIFF
--- a/local-script/contents/local-script
+++ b/local-script/contents/local-script
@@ -18,11 +18,11 @@ declare -ar ARGUMENTS=("$@")
 }
 
 if [ -z "${RD_CONFIG_TMP:-}" ]; then
-   scriptfile=$(mktemp -t "script.in.XXXX")
+   scriptfile=$(mktemp -t "script.$RD_JOB_EXECID.XXXXXX")
 else
    tmp_folder="${RD_CONFIG_TMP:-}"
    mkdir -p "$tmp_folder"
-   scriptfile="$tmp_folder/script-$RD_JOB_EXECID"
+   scriptfile=$(mktemp "$tmp_folder/script.$RD_JOB_EXECID.XXXXXX")
 fi
 
 # Write user defined script code to temp file.


### PR DESCRIPTION
Fix Jira: [RUN-3029](https://pagerduty.atlassian.net/br)

*nixy local script when a customer provides a tmp directory fails with (concurency >1) because the temp file was not unique per parallel excution.