### PR TITLE
update .github/workflows/build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,28 +25,28 @@ jobs:
       id: get_version
       run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
     - name: Upload command plugin zip
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.0.0
       with:
         # Artifact name
         name: command-${{ steps.get_version.outputs.VERSION }}
         # Directory containing files to upload
         path: ./command/build/libs/command-v${{ steps.get_version.outputs.VERSION }}.zip
     - name: Upload file plugin zip
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.0.0
       with:
         # Artifact name
         name: file-${{ steps.get_version.outputs.VERSION }}
         # Directory containing files to upload
         path: ./file/build/libs/file-v${{ steps.get_version.outputs.VERSION }}.zip
     - name: Upload local-script plugin zip
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.0.0
       with:
         # Artifact name
         name: local-script-${{ steps.get_version.outputs.VERSION }}
         # Directory containing files to upload
         path: ./local-script/build/libs/local-script-v${{ steps.get_version.outputs.VERSION }}.zip
     - name: Upload waitfor plugin zip
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3.0.0
       with:
         # Artifact name
         name: waitfor-${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,28 +25,28 @@ jobs:
       id: get_version
       run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
     - name: Upload command plugin zip
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         # Artifact name
         name: command-${{ steps.get_version.outputs.VERSION }}
         # Directory containing files to upload
         path: ./command/build/libs/command-v${{ steps.get_version.outputs.VERSION }}.zip
     - name: Upload file plugin zip
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         # Artifact name
         name: file-${{ steps.get_version.outputs.VERSION }}
         # Directory containing files to upload
         path: ./file/build/libs/file-v${{ steps.get_version.outputs.VERSION }}.zip
     - name: Upload local-script plugin zip
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         # Artifact name
         name: local-script-${{ steps.get_version.outputs.VERSION }}
         # Directory containing files to upload
         path: ./local-script/build/libs/local-script-v${{ steps.get_version.outputs.VERSION }}.zip
     - name: Upload waitfor plugin zip
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         # Artifact name
         name: waitfor-${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
This PR updates the .github/workflows/build.yml file to address an issue related to the deprecated version of actions/upload-artifact: v1.0.0. The workflow has been updated to use the latest version of the action, actions/upload-artifact@v4, in compliance with the GitHub Actions updates.