### PR TITLE
Build Modernization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,54 +1,64 @@
 name: Java CI
 
-on: [push]
+on: 
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Get Fetch Tags
-      run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-home-cache-cleanup: true
+
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --parallel
+
     - name: Get Release Version
       id: get_version
-      run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+      run: |
+        VERSION=$(./gradlew currentVersion -q -Prelease.quiet)
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Upload command plugin zip
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v4
       with:
-        # Artifact name
         name: command-${{ steps.get_version.outputs.VERSION }}
-        # Directory containing files to upload
         path: ./command/build/libs/command-v${{ steps.get_version.outputs.VERSION }}.zip
+        if-no-files-found: error
+
     - name: Upload file plugin zip
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v4
       with:
-        # Artifact name
         name: file-${{ steps.get_version.outputs.VERSION }}
-        # Directory containing files to upload
         path: ./file/build/libs/file-v${{ steps.get_version.outputs.VERSION }}.zip
+        if-no-files-found: error
+
     - name: Upload local-script plugin zip
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v4
       with:
-        # Artifact name
         name: local-script-${{ steps.get_version.outputs.VERSION }}
-        # Directory containing files to upload
         path: ./local-script/build/libs/local-script-v${{ steps.get_version.outputs.VERSION }}.zip
+        if-no-files-found: error
+
     - name: Upload waitfor plugin zip
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v4
       with:
-        # Artifact name
         name: waitfor-${{ steps.get_version.outputs.VERSION }}
-        # Directory containing files to upload
         path: ./waitfor/build/libs/waitfor-v${{ steps.get_version.outputs.VERSION }}.zip
+        if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
@@ -10,23 +9,37 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-home-cache-cleanup: true
+
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build --parallel
+
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: |
+          VERSION=$(./gradlew currentVersion -q -Prelease.quiet)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.0.0
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -36,45 +49,41 @@ jobs:
           prerelease: false
 
       - name: Upload Command Plugin (zip)
-        id: upload-release-asset-command
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./command/build/libs/command-v${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: command-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Upload File Plugin (zip)
-        id: upload-release-asset-file
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./file/build/libs/file-v${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: file-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Upload local-script Plugin (zip)
-        id: upload-release-asset-loca-script
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./local-script/build/libs/local-script-v${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: local-script-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Upload waitfor Plugin (zip)
-        id: upload-release-asset-waitfor
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./waitfor/build/libs/waitfor-v${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: waitfor-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,5 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
 plugins {
-    id 'pl.allegro.tech.build.axion-release' version '1.11.0'
+    id 'pl.allegro.tech.build.axion-release' version '1.18.17'
 }
 
 scmVersion {
@@ -12,10 +7,9 @@ scmVersion {
     tag {
         prefix = 'v'
         versionSeparator = ''
-        def origDeserialize=deserialize
-        //apend .0 to satisfy semver if the tag version is only X.Y
-        deserialize = { config, position, tagName ->
-            def orig = origDeserialize(config, position, tagName)
+        deserializer { config, position, tagName ->
+            def orig = tagName.startsWith('v') ? tagName.substring(1) : tagName
+            // Append .0 to satisfy semver if the tag version is only X.Y
             if (orig.split('\\.').length < 3) {
                 orig += ".0"
             }
@@ -24,7 +18,9 @@ scmVersion {
     }
 }
 
-
 allprojects {
-
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
 }

--- a/command/build.gradle
+++ b/command/build.gradle
@@ -9,4 +9,4 @@ ext.pluginBaseFolder ="."
 project.version = 'v' + scmVersion.version
 ext.archiveFilename = ext.archivesBaseName + '-' + version
 
-apply from: 'https://raw.githubusercontent.com/rundeck-plugins/build-zip/master/build.gradle'
+apply from: '../plugin-build.gradle'

--- a/file/build.gradle
+++ b/file/build.gradle
@@ -9,4 +9,4 @@ ext.pluginBaseFolder ="."
 project.version = 'v' + scmVersion.version
 ext.archiveFilename = ext.archivesBaseName + '-' + version
 
-apply from: 'https://raw.githubusercontent.com/rundeck-plugins/build-zip/master/build.gradle'
+apply from: '../plugin-build.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,11 @@
 group=org.rundeck.rundeck-plugins
+
+# Modern Gradle configuration
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.daemon=true
+
+# Java toolchain configuration
+org.gradle.java.installations.auto-detect=true
+org.gradle.java.installations.auto-download=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 27 15:55:21 CLT 2017
+#Updated to modern Gradle version for Java 11+ compatibility
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip

--- a/local-script/build.gradle
+++ b/local-script/build.gradle
@@ -9,5 +9,5 @@ ext.pluginBaseFolder ="."
 project.version = 'v' + scmVersion.version
 ext.archiveFilename = ext.archivesBaseName + '-' + version
 
-apply from: 'https://raw.githubusercontent.com/rundeck-plugins/build-zip/master/build.gradle'
+apply from: '../plugin-build.gradle'
 

--- a/plugin-build.gradle
+++ b/plugin-build.gradle
@@ -1,0 +1,78 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
+defaultTasks 'build'
+
+task pluginZip(type: Jar) {
+    destinationDirectory = file("build/libs")
+    archiveBaseName = project.ext.archivesBaseName
+    archiveVersion = project.version
+    archiveClassifier = ''
+    archiveExtension = 'zip'
+
+    from("${project.buildDir}/zip-contents") {
+        include("*.yaml")
+        include("resources/**")
+        include("contents/*")
+        into(archiveFileName)
+    }
+
+    manifest {
+        attributes 'Rundeck-Plugin-Name': pluginName.toString(),
+                   'Rundeck-Plugin-Description': pluginDescription.toString(),
+                   'Rundeck-Plugin-Archive': 'true',
+                   'Rundeck-Plugin-File-Version': version,
+                   'Rundeck-Plugin-Author': sopsCopyright,
+                   'Rundeck-Plugin-URL': sopsUrl,
+                   'Rundeck-Plugin-Date': buildDateString
+    }
+}
+
+pluginZip.doFirst {
+    def assetsMap = new Properties()
+    def tokens = assetsMap + [
+            version    : version,
+            date       : new Date().format("yyyy-MM-dd'T'HH:mm:ssX").toString(),
+            author     : sopsCopyright,
+            url        : sopsUrl,
+            title      : pluginName,
+            description: pluginDescription,
+            name       : archivesBaseName.toString(),
+    ]
+
+    copy {
+        from("${project.projectDir}/resources"){
+            include '**/*'
+            into "resources"
+        }
+        from("${project.projectDir}/contents"){
+            into "contents"
+        }
+        from("${project.projectDir}/plugin.yaml") {
+            filter(ReplaceTokens, tokens: tokens)
+            exclude '**/*.png'
+        }
+        into "${project.buildDir}/zip-contents"
+    }
+}
+
+apply plugin: 'maven-publish'
+
+publishing {
+    publications {
+        mavenZip(MavenPublication) {
+            artifact pluginZip
+        }
+    }
+}
+
+defaultTasks 'clean', 'build','pluginZip'
+
+task build(dependsOn: ['pluginZip']) {
+}
+
+task install(dependsOn: ['build','publishToMavenLocal']) {
+}
+
+task clean(type: Delete) {
+    delete('build')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,7 @@
+rootProject.name = 'nixy-step-plugins'
+
 include 'waitfor', 'file', 'local-script', 'command'
+
+// Enable modern Gradle features
+enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 

--- a/waitfor/build.gradle
+++ b/waitfor/build.gradle
@@ -9,5 +9,5 @@ ext.pluginBaseFolder ="."
 project.version = 'v' + scmVersion.version
 ext.archiveFilename = ext.archivesBaseName + '-' + version
 
-apply from: 'https://raw.githubusercontent.com/rundeck-plugins/build-zip/master/build.gradle'
+apply from: '../plugin-build.gradle'
 


### PR DESCRIPTION
Gradle Wrapper Modernization:

Updated from Gradle 3.5 (2017) to Gradle 8.5 (2023) Fixed Java version compatibility issues
Build Configuration Updates:

Modernized build.gradle with updated axion-release plugin (1.18.17) Fixed deprecated syntax in scmVersion configuration Added modern Gradle properties for performance optimization Updated settings.gradle with modern syntax and type-safe project accessors Plugin Build Script:

Created local plugin-build.gradle to replace deprecated remote script Fixed destinationDir → destinationDirectory and other deprecated properties Updated all subprojects to use the modernized local build script GitHub Workflows Modernization:

Updated build.yml and release.yml to use modern actions Upgraded from deprecated Java 8 to Java 11
Added proper Gradle caching and parallel builds
Fixed deprecated GitHub Actions syntax (::set-output → $GITHUB_OUTPUT) Left snyk-scan.yml unchanged as requested (already current)