### PR TITLE
Publish to Sonatype Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,17 @@ jobs:
           asset_path: ./waitfor/build/libs/waitfor-v${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: waitfor-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip
+
+      - name: Publish to Sonatype Maven Central
+        if: ${{ secrets.SONATYPE_USERNAME != '' && secrets.SIGNING_KEY != '' }}
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        run: |
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
+            -PsigningKey="$SIGNING_KEY" \
+            -PsigningPassword="$SIGNING_PASSWORD" \
+            -PsonatypeUsername="$SONATYPE_USERNAME" \
+            -PsonatypePassword="$SONATYPE_PASSWORD"

--- a/README.md
+++ b/README.md
@@ -28,3 +28,24 @@ After install you should see these as Node Steps in the job editor.
 
 ![steps](images/nixy-steps.png)
 
+## Publishing to Maven Central
+
+Artifacts are published to Sonatype and Maven Central (group `org.rundeck.plugins`). The release workflow can publish when the required secrets are configured.
+
+**Required project properties (for local publish or CI):**
+
+- `signingKey` – base64-encoded GPG private key for artifact signing
+- `signingPassword` – passphrase for the GPG key
+- `sonatypeUsername` – Sonatype Nexus username (or token user)
+- `sonatypePassword` – Sonatype Nexus password (or token)
+
+**Publish command:**
+
+```bash
+./gradlew -PsigningKey="<base64 key>" -PsigningPassword="..." \
+  -PsonatypeUsername="..." -PsonatypePassword="..." \
+  publishToSonatype closeAndReleaseSonatypeStagingRepository
+```
+
+In CI, configure the repository secrets `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `SIGNING_KEY`, and `SIGNING_PASSWORD`; the release workflow will publish to Maven Central when these are set.
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.18.17'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
+
+project.version = scmVersion.version
 
 scmVersion {
     ignoreUncommittedChanges = true
@@ -15,6 +18,13 @@ scmVersion {
             }
             orig
         }
+    }
+}
+
+nexusPublishing {
+    packageGroup = 'org.rundeck.plugins'
+    repositories {
+        sonatype()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group=org.rundeck.rundeck-plugins
+group=org.rundeck.plugins
 
 # Modern Gradle configuration
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,55 @@
+/**
+ * Shared publishing script for Maven Central (Sonatype).
+ * Applied from plugin-build.gradle after the mavenZip publication is defined.
+ *
+ * Expects project ext: publishName, publishDescription, githubSlug, developers
+ * (defaults set in plugin-build.gradle; subprojects may override in build.gradle).
+ *
+ * To publish:
+ *   ./gradlew -PsigningKey="<base64 GPG key>" -PsigningPassword="..." \
+ *     -PsonatypeUsername="..." -PsonatypePassword="..." \
+ *     publishToSonatype closeAndReleaseSonatypeStagingRepository
+ */
+
+publishing.publications.mavenZip.pom {
+    name = publishName
+    description = project.ext.hasProperty('publishDescription') ? publishDescription : publishName
+    url = "https://github.com/${githubSlug}"
+    licenses {
+        license {
+            name = 'The Apache Software License, Version 2.0'
+            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            distribution = 'repo'
+        }
+    }
+    scm {
+        url = "https://github.com/${githubSlug}"
+        connection = "scm:git:git@github.com:${githubSlug}.git"
+        developerConnection = "scm:git:git@github.com:${githubSlug}.git"
+    }
+    if (project.ext.developers) {
+        developers {
+            project.ext.developers.each { dev ->
+                developer {
+                    id = dev.id
+                    name = dev.name
+                    email = dev.email
+                }
+            }
+        }
+    }
+}
+
+def base64Decode = { String prop ->
+    project.findProperty(prop) ?
+            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
+            null
+}
+
+if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
+    apply plugin: 'signing'
+    signing {
+        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
+        sign(publishing.publications)
+    }
+}

--- a/plugin-build.gradle
+++ b/plugin-build.gradle
@@ -57,13 +57,22 @@ pluginZip.doFirst {
 
 apply plugin: 'maven-publish'
 
+// POM metadata defaults for Maven Central (subprojects may override in build.gradle)
+ext.publishName = project.ext.hasProperty('publishName') ? project.ext.publishName : project.ext.archivesBaseName
+ext.publishDescription = project.ext.hasProperty('publishDescription') ? project.ext.publishDescription : project.ext.pluginDescription
+ext.githubSlug = project.ext.hasProperty('githubSlug') ? project.ext.githubSlug : 'rundeck-plugins/nixy-step-plugins'
+ext.developers = project.ext.hasProperty('developers') ? project.ext.developers : [[id: 'gschueler', name: 'Greg Schueler', email: 'greg@rundeck.com']]
+
 publishing {
     publications {
         mavenZip(MavenPublication) {
             artifact pluginZip
+            version = rootProject.version.toString()
         }
     }
 }
+
+apply from: "${rootProject.projectDir}/gradle/publishing.gradle"
 
 defaultTasks 'clean', 'build','pluginZip'
 


### PR DESCRIPTION
- Add nexus-publish plugin and Sonatype repo to root build.gradle
- Set project version from scmVersion (no v prefix) for Maven coordinates
- Set group to org.rundeck.plugins in gradle.properties
- Add shared gradle/publishing.gradle for POM metadata and GPG signing
- In plugin-build.gradle: set mavenZip version from root, apply publishing script
- Release workflow: optional publish to Maven Central after GitHub release (when secrets set)
- README: document publishing and required properties