### PR TITLE
[RUN-3477] Add tmp config field to nixy-local-workflow-step

### DIFF
--- a/local-script/plugin.yaml
+++ b/local-script/plugin.yaml
@@ -33,7 +33,12 @@ providers:
         name: arguments
         title: Arguments
         description: "optional command line arguments"
-        required: false   
+        required: false
+      - type: String
+        name: tmp
+        title: Temporary path
+        description: "Temporary path where the script will be copied, default /tmp"
+        required: false
   - name: nixy-local-node-step
     service: WorkflowNodeStep
     title: '*nixy / local-script'


### PR DESCRIPTION
## Summary

Adds the `tmp` config field to the `nixy-local-workflow-step` provider, mirroring the field already present on `nixy-local-node-step`.

Without this field declared in `plugin.yaml`, Rundeck cannot cascade `project.plugin.WorkflowStep.nixy-local-workflow-step.tmp` from project-level config, so `RD_CONFIG_TMP` is never set and the bash script always falls through to `mktemp` default (`/tmp`).

## Change

One field added to `nixy-local-workflow-step` config in `local-script/plugin.yaml`:

```yaml
- type: String
  name: tmp
  title: Temporary path
  description: "Temporary path where the script will be copied, default /tmp"
  required: false
```

The bash script (`local-script/contents/local-script`) already handles `$RD_CONFIG_TMP` correctly — **no script changes needed**.

## Test plan

- [ ] Build and install the plugin in a Rundeck instance
- [ ] Confirm "Temporary path" field appears in the UI when configuring a `*nixy / local-script` workflow step
- [ ] Set `project.plugin.WorkflowStep.nixy-local-workflow-step.tmp=/some/custom/dir` in project properties
- [ ] Run a job using `nixy-local-workflow-step` with a script that outputs `echo "Script dir: $(dirname $0)"`
- [ ] Verify log contains `/some/custom/dir` instead of `/tmp`

## Related

- Jira: RUN-3477
- Companion PR in rundeckpro (version bump): https://github.com/rundeckpro/rundeckpro/pull/4717
- Prior report: RUN-2447 (same root cause, closed without fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)