### PR TITLE
[RUN-4568] Add prepare-community-pr reusable workflow caller

### DIFF
--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -1,0 +1,12 @@
+name: Prepare community PR
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  prepare:
+    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds a lightweight caller workflow (`.github/workflows/prepare-community-pr.yml`) that invokes the centralized reusable workflow from `rundeck/rundeck` (merged in https://github.com/rundeck/rundeck/pull/10242).
- Enables full CI (including jobs requiring repo secrets) for approved community PRs without duplicating the 244-line workflow logic.
- Non-breaking: only activates when the `prepare-community-pr` label is applied to an open PR.

## Test plan

- [x] Verify the workflow file is valid YAML and references the correct reusable workflow path
- [x] Confirm that labeling a community PR with `prepare-community-pr` triggers the workflow
- [x] Confirm no existing workflows are affected


Made with [Cursor](https://cursor.com)