### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -40,10 +42,40 @@ jobs:
             ./waitfor/build/libs/waitfor-${{ steps.get_version.outputs.VERSION }}.zip#waitfor-${{ steps.get_version.outputs.VERSION }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: |
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          # Each subproject (command, file, local-script, waitfor) publishes its own
+          # mavenZip publication under org/rundeck/plugins/<module>/, artifactId == module name.
+          for MODULE in command file local-script waitfor; do
+            BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/${MODULE}/${VERSION}"
+            sign_and_upload "${MODULE}/build/libs/${MODULE}-${VERSION}.zip" "${MODULE}-${VERSION}.jar"
+            sign_and_upload "${MODULE}/build/publications/mavenZip/pom-default.xml" "${MODULE}-${VERSION}.pom"
+          done
+        env:
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.21.2'
-    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 group = 'org.rundeck.plugins'
@@ -17,14 +16,4 @@ scmVersion {
 allprojects {
     group = 'org.rundeck.plugins'
     version = rootProject.scmVersion.version
-}
-
-nexusPublishing {
-    packageGroup = 'org.rundeck.plugins'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
 }

--- a/gradle/nixy-subproject-publishing.gradle
+++ b/gradle/nixy-subproject-publishing.gradle
@@ -6,7 +6,8 @@
  *   ext.developers = [ [...] ]
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
 
 publishing {
     publications {
@@ -52,32 +53,16 @@ publishing {
         }
     }
     repositories {
-        def pkgcldWriteToken = System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken")
-        if (pkgcldWriteToken) {
-            maven {
-                name = "PackageCloudTest"
-                url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = "Bearer " + pkgcldWriteToken
-                }
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
             }
         }
-    }
-}
-
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Description

Migrate `nixy-step-plugins` publishing from Maven Central (Sonatype) to PackageCloud, applying the same design already validated on [rundeck-plugins/sshj-plugin#136](https://github.com/rundeck-plugins/sshj-plugin/pull/136) and the other already-migrated `rundeck-plugins` repos. Part of the RUN-4570 Maven Central publishing limits resolution — plugins account for the bulk of the file/release count on Maven Central, but no external project depends on them as Maven dependencies.

This repo bundles four subprojects (`command`, `file`, `local-script`, `waitfor`), each publishing its own `mavenZip` publication through the shared `gradle/nixy-subproject-publishing.gradle`, so all four are migrated together in one pass.

- Removed `nexusPublish`/`nexusPublishing` from the root `build.gradle`.
- Point the PackageCloud maven repo at the configurable `PKGCLD_REPO_URL` env var (with a fallback to the real `rundeck-plugins` repo), replacing the half-migrated `PackageCloudTest` block that pointed at `rundeckpro-test`, in the shared subproject publishing file.
- Dropped Gradle-side GPG signing (`sign(publishing.publications)`): PackageCloud's Maven endpoint rejects the checksum Gradle auto-generates for `.asc` signature files (422 Unprocessable Entity). Sign and upload via `gpg` CLI + `curl` instead, directly in `release.yml` — the same mechanism validated end-to-end on `sshj-plugin`.
- `release.yml`: replaced the single "Publish to Maven Central" step (which published all 4 subprojects via one `publishToSonatype` call) with a "Publish to PackageCloud" step (`publishAllPublicationsToPackageCloudRepository`, which Gradle runs across all 4 subprojects the same way) + a "Sign and upload GPG signatures" step that loops over all 4 modules, signing each one's zip (published with a `.jar` extension override, same as `docker`) and pom.

## Testing instructions

- Merge this PR.
- Tag a version to trigger the release workflow.
- Verify all 4 artifacts (`command`, `file`, `local-script`, `waitfor`) and their `.asc` signatures land under `org/rundeck/plugins/<module>/<version>/` on PackageCloud.
- Verify `./gradlew build --parallel` still succeeds without `PKGCLD_REPO_URL` set.
