### PR TITLE
[RUN-4721] Let local-script choose unexpandable mode in the UI

### DIFF
--- a/local-script/plugin.yaml
+++ b/local-script/plugin.yaml
@@ -21,12 +21,25 @@ providers:
     script-file: local-script
     script-args: ${config.arguments}
     config:
+      - type: Select
+        name: unexpandableMode
+        title: Unresolved variable handling
+        description: >
+          Default blanks unresolved ${...} refs (classic).
+          Choose "Preserve bash" only if the script needs bash ${VAR} / ${VAR:-default}
+          while still blanking unresolved Rundeck refs like ${option.x}.
+        values: blank,preserveBash
+        labels:
+          blank: Blank unresolved (default)
+          preserveBash: Preserve bash ${VAR}
+        default: blank
+        required: true
       - type: String
         name: script
         title: script
         description: "the shell script"
         required: true
-        blankIfUnexpandable: false
+        unexpandableBehaviorFrom: unexpandableMode
         renderingOptions:
           displayType: CODE
           codeSyntaxMode: SH
@@ -49,12 +62,25 @@ providers:
     script-file: local-script
     script-args: ${config.arguments}
     config:
+      - type: Select
+        name: unexpandableMode
+        title: Unresolved variable handling
+        description: >
+          Default blanks unresolved ${...} refs (classic).
+          Choose "Preserve bash" only if the script needs bash ${VAR} / ${VAR:-default}
+          while still blanking unresolved Rundeck refs like ${option.x}.
+        values: blank,preserveBash
+        labels:
+          blank: Blank unresolved (default)
+          preserveBash: Preserve bash ${VAR}
+        default: blank
+        required: true
       - type: String
         name: script
         title: script
         description: "the shell script"
         required: true
-        blankIfUnexpandable: false
+        unexpandableBehaviorFrom: unexpandableMode
         renderingOptions:
           displayType: CODE
           codeSyntaxMode: SH
@@ -68,4 +94,3 @@ providers:
         title: Temporary path
         description: "Temporary path where the script will be copied, default /tmp"
         required: false
-

--- a/local-script/test/test-local-script.sh
+++ b/local-script/test/test-local-script.sh
@@ -63,14 +63,37 @@ export TEST_ENV_VAR="env_value"
 output=$(run_script 'echo "result: ${TEST_ENV_VAR}"')
 assert_output "\${ENV_VAR} expands from environment" "result: env_value" "$output"
 
-# --- Test 4: plugin.yaml declares blankIfUnexpandable: false ---
-echo "Test 4: plugin.yaml has blankIfUnexpandable: false"
-count=$(grep -c "blankIfUnexpandable: false" "$PLUGIN_YAML")
-if [[ "$count" -eq 2 ]]; then
-    echo "  PASS: attribute set on both providers"
+# --- Test 4: plugin.yaml wires user Select via unexpandableBehaviorFrom ---
+echo "Test 4: plugin.yaml has unexpandableBehaviorFrom + Select"
+from_count=$(grep -c "unexpandableBehaviorFrom: unexpandableMode" "$PLUGIN_YAML")
+mode_count=$(grep -c "name: unexpandableMode" "$PLUGIN_YAML")
+if [[ "$from_count" -eq 2 && "$mode_count" -eq 2 ]]; then
+    echo "  PASS: From + Select on both providers"
     ((PASS++))
 else
-    echo "  FAIL: expected 2 occurrences, found $count"
+    echo "  FAIL: expected 2 From and 2 Select names, found from=$from_count mode=$mode_count"
+    ((FAIL++))
+fi
+
+# --- Test 5: blankIfUnexpandable:false removed ---
+echo "Test 5: blankIfUnexpandable:false not present"
+if grep -q "blankIfUnexpandable: false" "$PLUGIN_YAML"; then
+    echo "  FAIL: blankIfUnexpandable:false should be removed"
+    ((FAIL++))
+else
+    echo "  PASS: blankIfUnexpandable:false absent"
+    ((PASS++))
+fi
+
+# --- Test 6: Select defaults to blank; preserveBash is opt-in ---
+echo "Test 6: Select defaults to blank"
+if grep -q "values: blank,preserveBash" "$PLUGIN_YAML" && \
+   [[ $(grep -c "default: blank" "$PLUGIN_YAML") -eq 2 ]] && \
+   ! grep -q "unexpandableBehavior: preserveBash" "$PLUGIN_YAML"; then
+    echo "  PASS: blank default, no static preserveBash"
+    ((PASS++))
+else
+    echo "  FAIL: expected blank default and no static preserveBash fallback"
     ((FAIL++))
 fi
 


### PR DESCRIPTION
## Summary
- Removes `blankIfUnexpandable: false` from nixy local-script (both workflow and node providers).
- Adds step UI Select **Unresolved variable handling** (`blank` default, `preserveBash` opt-in).
- Wires `script` via `unexpandableBehaviorFrom: unexpandableMode` (needs Rundeck core from [rundeck/rundeck#10433](https://github.com/rundeck/rundeck/pull/10433)).

## Test plan
- [x] `bash local-script/test/test-local-script.sh`
- [ ] With core from #10433: default `blank` blanks unresolved refs (classic)
- [ ] Select `preserveBash`: empty multivalued `${option.op1}` does not cause `bad substitution`
- [ ] Select `preserveBash`: bash `${MYVAR}` / `${MYVAR:-x}` still work in the script

Jira: https://pagerduty.atlassian.net/browse/RUN-4721


Made with [Cursor](https://cursor.com)